### PR TITLE
Escape output & framePattern paths due to spaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,15 +121,19 @@ module.exports = async (opts) => {
       .run()
   })
 
+  
   if (isGIF) {
     const framePattern = tempOutput.replace('%d', '*')
+    
+    const escapePath = arg => arg.replace(/(\s+)/g, '\\$1')
+
     const params = [
-      '-o', output,
+      '-o', escapePath(output),
       '--fps', gifski.fps,
       gifski.fast && '--fast',
       '--quality', gifski.quality,
       '--quiet',
-      framePattern
+      escapePath(framePattern)
     ].filter(Boolean)
 
     const executable = process.env.GIFSKI_PATH || 'gifski'

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ module.exports = async (opts) => {
       .on('error', (err) => reject(err))
       .run()
   })
-  
+
   if (isGIF) {
     const framePattern = tempOutput.replace('%d', '*')
     const escapePath = arg => arg.replace(/(\s+)/g, '\\$1')

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,11 +120,9 @@ module.exports = async (opts) => {
       .on('error', (err) => reject(err))
       .run()
   })
-
   
   if (isGIF) {
     const framePattern = tempOutput.replace('%d', '*')
-    
     const escapePath = arg => arg.replace(/(\s+)/g, '\\$1')
 
     const params = [


### PR DESCRIPTION
When executing the command, the relevant characters of the argument(s) should be escaped.